### PR TITLE
#160609512 Setup codeclimate tool.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8
+    branches:
+    steps:
+      - checkout
+      - restore_cache: # special step to restore the dependency cache
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Setup Dependencies
+          command: npm install
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+      - save_cache: # special step to save the dependency cache
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+      - run: # run tests
+          name: Run Test and Coverage
+          command: |
+            ./cc-test-reporter before-build
+            yarn test --coverage
+            ./cc-test-reporter format-coverage coverage/lcov.info -t lcov
+            ./cc-test-reporter upload-coverage

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![Maintainability](https://api.codeclimate.com/v1/badges/6c1a018941b00be226b7/maintainability)](https://codeclimate.com/github/andela/ah-frontend-targaryen/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/6c1a018941b00be226b7/test_coverage)](https://codeclimate.com/github/andela/ah-frontend-targaryen/test_coverage)
 # ah-frontend-targaryen


### PR DESCRIPTION
### What does this PR do?
Enables reporting of test coverage to codeclimate.

#### Description of Task to be completed?
Currently, there is no way of seeing the quality of the code written.
This PR adds code-climate maintainability and test-coverage badges to show the code quality.

#### How should this be manually tested?
Go to the `ch-codeclimate-test-coverage-160609512` branch on this github repository and the badges should be displayed in the README.

#### Background context?
The test-coverage badge displays `?` because codeclimate is pointed towards develop which is the default branch in this repo. Merging the branch into develop should rectify this.

#### What are the relevant pivotal tracker stories?
[160609512](https://www.pivotaltracker.com/story/show/160609512)