### PR TITLE
#161647343 fix coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/6c1a018941b00be226b7/maintainability)](https://codeclimate.com/github/andela/ah-frontend-targaryen/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/6c1a018941b00be226b7/test_coverage)](https://codeclimate.com/github/andela/ah-frontend-targaryen/test_coverage)
 [![Build Status](https://travis-ci.org/andela/ah-frontend-targaryen.svg?branch=develop)](https://travis-ci.org/andela/ah-frontend-targaryen)
-[![Coverage Status](https://coveralls.io/repos/github/andela/ah-frontend-targaryen/badge.svg?branch=ch-travis-setup-160609508)](https://coveralls.io/github/andela/ah-frontend-targaryen?branch=ch-travis-setup-160609508)
+[![Coverage Status](https://coveralls.io/repos/github/andela/ah-frontend-targaryen/badge.svg?branch=develop)](https://coveralls.io/github/andela/ah-frontend-targaryen?branch=develop)
 # ah-frontend-targaryen


### PR DESCRIPTION
#### What does this PR do?
Fix the coverage that is displayed by the coveralls badge

#### Description of Task to be completed?

Currently, the coveralls badge displays 4% as opposed to 100% test coverage

This fixes the coveralls badge to display the right value that is 100% by pointing to the develop branch


#### How should this be manually tested?

Navigate to the branch [here](https://github.com/andela/ah-frontend-targaryen/tree/bg-fix-coverallsbadge-161647343), scroll to the `README.md` to see the badge

#### What are the relevant pivotal tracker stories?

[#161647343](https://www.pivotaltracker.com/story/show/161647343)



#### Any background context you want to add?
N/A



#### Screenshots
![image](https://user-images.githubusercontent.com/9901011/47852427-cc099300-ddec-11e8-9391-b150e82c226d.png)
