### PR TITLE
fix(signup): fix signup password field

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -13,6 +13,7 @@ export const fetchUsers = (postData) => dispatch => {
     .post('/api/users/', postData)
     .then((response) => {
       localStorage.setItem('auth_token', response.data.user.auth_token);
+      localStorage.setItem('username', response.data.user.username);
       dispatch({ type: REGISTER_USER_SUCCESS, payload: true });
       toast.success('Signup successful', { autoClose: 3500, hideProgressBar: true });
     })
@@ -35,7 +36,8 @@ export const loginUser = payload => async dispatch => {
   axiosInstance
     .post('/api/users/login/', payload)
     .then(response => {
-      localStorage.setItem('token', response.data.user.auth_token);
+      localStorage.setItem('auth_token', response.data.user.auth_token);
+      localStorage.setItem('username', response.data.user.username);
       dispatch({ type: LOGIN_USER_SUCCESS, payload: true });
       toast.success(
         'Logged In!',

--- a/src/components/register/RegisterUser.js
+++ b/src/components/register/RegisterUser.js
@@ -60,21 +60,21 @@ export class RegisterUser extends Component {
                   </div>
                 </div>
                 <div className="form-group">
-                  <label className="control-label" htmlFor="password">Password</label>
-                  <div className="input-group mb-2">
-                    <div className="input-group-prepend">
-                      <div className="input-group-text"><i className="fas fa-key" /></div>
-                    </div>
-                    <input type="password" className="form-control" name="password" id="password" value={password} onChange={this.handleChange} />
-                  </div>
-                </div>
-                <div className="form-group">
                   <label className="control-label" htmlFor="username">Username</label>
                   <div className="input-group mb-2">
                     <div className="input-group-prepend">
                       <div className="input-group-text"><i className="fas fa-user" /></div>
                     </div>
                     <input type="text" className="form-control" name="username" id="username" value={username} onChange={this.handleChange} />
+                  </div>
+                </div>
+                <div className="form-group">
+                  <label className="control-label" htmlFor="password">Password</label>
+                  <div className="input-group mb-2">
+                    <div className="input-group-prepend">
+                      <div className="input-group-text"><i className="fas fa-key" /></div>
+                    </div>
+                    <input type="password" className="form-control" name="password" id="password" value={password} onChange={this.handleChange} />
                   </div>
                 </div>
                 <button className="btn btn-block btn-primary" type="submit" value="Submit">Submit</button>


### PR DESCRIPTION
This PR adds the password field to the end of the signup form.

#### How should this be manually tested?

Run the Authors Heaven application `npm start`
Navigate to signup page.
The Password field should be the last in the registration form

#### What are the relevant pivotal tracker stories?

[#161775020](https://www.pivotaltracker.com/story/show/161775020)



#### Any background context you want to add?
N/A



#### Screenshots
<img width="453" alt="screen shot 2018-11-07 at 12 00 01" src="https://user-images.githubusercontent.com/38077368/48120964-b4b32580-e284-11e8-8569-bda972cb63e1.png">
