### PR TITLE
#162043486 Users should redirect to dashboard after login

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-toastify": "^4.4.0",
     "redux": "^4.0.1",
     "redux-mock-store": "^1.5.3",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "sinon": "^7.1.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -173,3 +173,9 @@ export const resetPassword = (passwordDetails) => dispatch => {
       return toast.error('Connection Error', { autoClose: 3500, hideProgressBar: true });
     });
 };
+
+export const logOut = () => dispatch => {
+  localStorage.removeItem('auth_token');
+  localStorage.removeItem('username');
+  dispatch({ type: LOGOUT_USER, payload: false });
+};

--- a/src/components/landingPage/LandingPage.js
+++ b/src/components/landingPage/LandingPage.js
@@ -1,26 +1,49 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import Articles from '../Articles/Articles';
+import Dashboard from '../dashboard/Dashboard';
 
-const LandingPage = () => (
-  <React.Fragment>
-    <div className="first-section">
-      <div className="container">
-        <div className="row">
-          <div className="col-12 jumbotron mx-auto lp-intro lp-text">
-            <p>Authors Haven is the one stop hub for knowledge.</p>
-            <p>Come take a look at thousands of articles.</p>
-            <p>You can even share your own!!!</p>
-            <a href="#start" className="btn ah-btn">
-              Join us and share your ideas
-            </a>
+export const LandingPage = ({ isLoggedIn }) =>
+  (
+    <div>
+      {!isLoggedIn
+        ? (<React.Fragment>
+          <div className="first-section">
+            <div className="container">
+              <div className="row">
+                <div className="col-12 jumbotron mx-auto lp-intro lp-text">
+                  <p>Authors Haven is the one stop hub for knowledge.</p>
+                  <p>Come take a look at thousands of articles.</p>
+                  <p>You can even share your own!!!</p>
+                  <a href="#start" className="btn ah-btn">
+                    Join us and share your ideas
+                  </a>
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
+          <div className="container-fluid article-list">
+            <Articles />
+          </div>
+        </React.Fragment>
+        ) : (
+          <Dashboard />
+        )
+      }
     </div>
-    <div className="container-fluid article-list">
-      <Articles />
-    </div>
-  </React.Fragment>
-);
+  );
 
-export default LandingPage;
+LandingPage.propTypes = {
+  isLoggedIn: PropTypes.bool,
+};
+
+LandingPage.defaultProps = {
+  isLoggedIn: false,
+};
+
+const mapStateToProps = state => ({
+  isLoggedIn: state.user.isLoggedIn,
+});
+
+export default connect(mapStateToProps)(LandingPage);

--- a/src/components/landingPage/Navbar.js
+++ b/src/components/landingPage/Navbar.js
@@ -59,10 +59,10 @@ export class Navbar extends Component {
                           <i className="fas fa-user" />
                         </a>
                         <div className="dropdown-menu" aria-labelledby="navbarDropdown">
-                          <NavLink className="dropdown-item" to="/create-article/">New Article</NavLink>
-                          <NavLink className="dropdown-item" to={`/profiles/${username}`}>Profile</NavLink>
+                          <NavLink className="dropdown-item" exact to="/create-article/">New Article</NavLink>
+                          <NavLink className="dropdown-item" exact to={`/profiles/${username}`}>Profile</NavLink>
                           <div className="dropdown-divider" />
-                          <NavLink className="dropdown-item" to="#">Logout</NavLink>
+                          <NavLink className="dropdown-item" to="/logout">Logout</NavLink>
                         </div>
                       </div>
                     </li>
@@ -71,12 +71,12 @@ export class Navbar extends Component {
                 : (
                   <React.Fragment>
                     <li className="nav-item active">
-                      <NavLink className="btn ah-btn ah-btn-nav js-scroll-trigger nav-link nav-text" to="signup">
+                      <NavLink className="btn ah-btn ah-btn-nav js-scroll-trigger nav-link nav-text" exact to="signup">
                         Signup
                       </NavLink>
                     </li>
                     <li className="nav-item">
-                      <NavLink className="btn ah-btn ah-btn-nav js-scroll-trigger nav-link nav-text" to="login">Login</NavLink>
+                      <NavLink className="btn ah-btn ah-btn-nav js-scroll-trigger nav-link nav-text" exact to="login">Login</NavLink>
                     </li>
                   </React.Fragment>
                 )

--- a/src/components/login/FacebookButton.js
+++ b/src/components/login/FacebookButton.js
@@ -39,7 +39,7 @@ class FacebookButton extends PureComponent {
   render() {
     const value = this.state;
     if (value.redirect) {
-      const to = { pathname: '/' };
+      const to = { pathname: '/dashboard' };
       return (
         <Redirect to={to} />
       );

--- a/src/components/login/GoogleButton.js
+++ b/src/components/login/GoogleButton.js
@@ -41,7 +41,7 @@ class GoogleloginButton extends PureComponent {
   render() {
     const value = this.state;
     if (value.redirect) {
-      const to = { pathname: '/' };
+      const to = { pathname: '/dashboard' };
       return (
         <Redirect to={to} />
       );
@@ -50,7 +50,7 @@ class GoogleloginButton extends PureComponent {
       <div>
         <GoogleLogin
           clientId="1040550554735-0lfo665jrpgkprjkqdvh9njlc46mu6rg.apps.googleusercontent.com"
-          redirectUri="/"
+          redirectUri="/dashboard"
           onSuccess={this.handleGoogleResponse}
           onFailure={this.handleGoogleResponse}
           className="google"

--- a/src/components/login/Login.js
+++ b/src/components/login/Login.js
@@ -20,12 +20,23 @@ export class Login extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.isLoggedIn === true) {
-      const { history } = this.props;
-      history.push('/dashboard');
+  componentDidMount() {
+    const { isLoggedIn } = this.props;
+    if (isLoggedIn === true) {
+      this.redirectHome();
     }
   }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.isLoggedIn === true) {
+      this.redirectHome();
+    }
+  }
+
+  redirectHome = () => {
+    const { history } = this.props;
+    history.push('/dashboard');
+  };
 
   handleInput = event => {
     const { name } = event.target;
@@ -95,7 +106,7 @@ export class Login extends Component {
                 Login
               </button>
               <div className="form-group">
-                <Link className="forgot-password" to="/forgot-Password">Forgot password?</Link>
+                <Link className="forgot-password" exact to="/forgotPassword">Forgot password?</Link>
               </div>
               <div className="row">
                 <div className="col-md-6">

--- a/src/components/login/Logout.js
+++ b/src/components/login/Logout.js
@@ -1,0 +1,37 @@
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import '../../assets/App.css';
+import { logOut } from '../../actions/userActions';
+
+export class Logout extends Component {
+  componentWillMount() {
+    const { isLoggedIn } = this.props;
+    if (isLoggedIn === true) {
+      const { logOut } = this.props;
+      logOut();
+      const { history } = this.props;
+      history.push('/login');
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+Logout.propTypes = {
+  logOut: PropTypes.func.isRequired,
+  history: PropTypes.object.isRequired,
+  isLoggedIn: PropTypes.bool,
+};
+
+Logout.defaultProps = {
+  isLoggedIn: false,
+};
+
+const mapStateToProps = state => ({
+  isLoggedIn: state.user.isLoggedIn,
+});
+
+export default connect(mapStateToProps, { logOut })(Logout);

--- a/src/components/routes/PrivateRoute.js
+++ b/src/components/routes/PrivateRoute.js
@@ -1,0 +1,28 @@
+import { Redirect, Route } from 'react-router-dom';
+import React from 'react';
+import decode from 'jwt-decode';
+
+export const PrivateRoute = ({ component: Component, ...props }) => {
+  const authenticate = token => {
+    if (token) {
+      const decoded_token = decode(token);
+      if (decoded_token.exp > (Date.now()) / 1000) {
+        return { decoded_token };
+      }
+    }
+    return false;
+  };
+
+  const authenticated = authenticate(localStorage.getItem('auth_token'));
+
+  return (
+    <Route
+      {...props}
+      render={props =>
+        (authenticated ? <Component {...props} /> : <Redirect to="/login" />)
+      }
+    />
+  );
+};
+
+export default PrivateRoute;

--- a/src/components/routes/index.js
+++ b/src/components/routes/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import LandingPage from '../landingPage/LandingPage';
 import Login from '../login/Login';
+import Logout from '../login/Logout';
 import NotFound from '../notFound/NotFound';
 import RegisterUser from '../register/RegisterUser';
 import Dashboard from '../dashboard/Dashboard';
@@ -11,20 +12,22 @@ import Comments from '../comments/Comments';
 import EditArticle from '../Articles/EditArticle';
 import ResetPassword from '../resetPassword/ResetPasswordPage';
 import ForgotPassword from '../resetPassword/ForgotPasswordPage';
+import PrivateRoute from './PrivateRoute';
 
 const Routes = () => (
   <Switch>
     <Route exact path="/" component={LandingPage} />
     <Route exact path="/login" component={Login} />
-    <Route exact path="/signup" component={RegisterUser} />
-    <Route exact path="/dashboard" component={Dashboard} />
+    <Route exact path="/logout" component={Logout} />
+    <PrivateRoute exact path="/signup" component={RegisterUser} />
     <Route exact path="/forgot-password" component={ForgotPassword} />
     <Route exact path="/reset-password/:token" component={ResetPassword} />
-    <Route exact path="/profiles/:username" component={Profile} />
-    <Route exact path="/create-article" component={CreateArticle} />
-    <Route exact path="/articles/:article/comments/" component={Comments} />
-    <Route exact path="/article/:slug" component={EditArticle} />
-    <Route exact component={NotFound} />
+    <PrivateRoute exact path="/dashboard" component={Dashboard} />
+    <PrivateRoute exact path="/profiles/:username" component={Profile} />
+    <PrivateRoute exact path="/create-article" component={CreateArticle} />
+    <PrivateRoute exact path="/articles/:article/comments/" component={Comments} />
+    <PrivateRoute exact path="/article/:slug" component={EditArticle} />
+    <Route component={NotFound} />
   </Switch>
 );
 

--- a/src/tests/actions/userActions.test.js
+++ b/src/tests/actions/userActions.test.js
@@ -9,6 +9,7 @@ import {
   facebookLoginUser,
   getProfile,
   updateLoginStatus,
+  logOut,
 } from '../../actions/userActions';
 import {
   REGISTER_USER_SUCCESS,
@@ -19,6 +20,7 @@ import {
   SOCIAL_LOGIN_SUCCESS,
   GET_PROFILE_PAYLOAD,
   GET_PROFILE_INITIATED,
+  LOGOUT_USER,
 } from '../../actions/types';
 import axiosInstance from '../../config/axiosInstance';
 
@@ -254,5 +256,21 @@ describe('userAction', () => {
         { type: LOGIN_USER_SUCCESS, payload: false },
       ],
     );
+  });
+
+  it('should logout user when he/she clicks on LogOut menu', () => {
+    localStorage.setItem('auth_token', 'token');
+    store.dispatch(logOut());
+    expect(store.getActions()).toEqual(
+      [
+        { type: LOGOUT_USER, payload: false },
+      ],
+    );
+  });
+
+  it('should remove the auth_token when a user clicks on LogOut NavLink', () => {
+    localStorage.setItem('auth_token', 'token');
+    store.dispatch(logOut());
+    expect(!(localStorage.getItem('auth_token')));
   });
 });

--- a/src/tests/components/Landingpage.test.js
+++ b/src/tests/components/Landingpage.test.js
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import LandingPage from '../../components/landingPage/LandingPage';
+import { LandingPage } from '../../components/landingPage/LandingPage';
 import { Navbar } from '../../components/landingPage/Navbar';
 
 it('renders the LandingPage component correctly', () => {

--- a/src/tests/components/Login.test.js
+++ b/src/tests/components/Login.test.js
@@ -11,16 +11,24 @@ describe('Login component', () => {
     isLoggedIn: true,
   };
   const props = {
+    isLoggedIn: true,
     history: { push: jest.fn() },
     signIn: jest.fn(),
   };
-
+  const redirectHome = jest.fn();
 
   beforeEach(() => {
     mockStore({});
-    wrapper = shallow(<Login {...props} />);
+    wrapper = shallow(<Login
+      redirectHome={redirectHome}
+      componentDidMount={jest.fn()}
+      {...props}
+    />);
   });
 
+  afterEach(() => {
+    wrapper.unmount();
+  });
 
   it('should render correctly', () => {
     expect(wrapper).toMatchSnapshot();
@@ -40,13 +48,19 @@ describe('Login component', () => {
     expect(wrapper.state().email).toEqual('toniks@gmail.com');
   });
 
-  it('should not redirect if isLoggedIn is false', () => {
-    wrapper.setProps({ isLoggedIn: false });
-    expect(props.history.push).toBeCalledTimes(0);
+
+  it('should redirect if isLoggedIn is true', () => {
+    wrapper.setProps({ isLoggedIn: true });
+    expect(props.history.push).toBeCalled();
   });
 
-  it('should redirect on successful login', () => {
+  it('should redirect to dashboard when login is successful', () => {
     wrapper.setProps({ ...nextProps });
+    expect(props.history.push).toBeCalledWith('/dashboard');
+  });
+
+  it('should call redirectHome when component mounts with isLoggedIn as true', () => {
+    wrapper.setProps({ ...props });
     expect(props.history.push).toBeCalledWith('/dashboard');
   });
 });

--- a/src/tests/components/Logout.test.js
+++ b/src/tests/components/Logout.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import { Logout } from '../../components/login/Logout';
+
+
+describe('Login component', () => {
+  const mockStore = configureMockStore();
+  let wrapper;
+  const props = {
+    history: { push: jest.fn() },
+    logOut: jest.fn(),
+    isLoggedIn: true,
+  };
+
+
+  beforeEach(() => {
+    mockStore({});
+    wrapper = shallow(<Logout {...props} />);
+  });
+
+  it('should redirect user to login page', () => {
+    wrapper.setProps({ isLoggedIn: true });
+    expect(props.history.push).toBeCalledTimes(1);
+  });
+
+  it('should render correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/tests/routes/PrivateRoute.test.js
+++ b/src/tests/routes/PrivateRoute.test.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { shallow, mount } from 'enzyme';
+import PrivateRoute from '../../components/routes/PrivateRoute';
+
+class TestComponent extends Component {
+  render() {
+    return (
+      <h1>Test Component</h1>
+    );
+  }
+}
+
+describe('PrivateRoute Component', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(
+      <BrowserRouter>
+        <PrivateRoute
+          component={TestComponent}
+        />
+      </BrowserRouter>,
+    );
+  });
+
+
+  it('should render correctly', () => {
+    localStorage.setItem('auth_token', 'my athentication token');
+    wrapper = shallow(
+      <BrowserRouter>
+        <PrivateRoute
+          component={TestComponent}
+        />
+      </BrowserRouter>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render TestComponent if the auth_token is valid', () => {
+    localStorage.setItem('auth_token', 'my athentication token');
+    expect(wrapper.find(TestComponent)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### What does this PR do?

- Users should be redirected to dashboard after login
- All other routes should be protected
- A user should be able to log-out

#### Description of Task to be completed?

Currently, the user can not logout of the app and when he/she logs in, they are redirected to the landing page of the app. Also the user is able access other routes such as profile before they login which makes the app insecure. 

This chore enables users to log out of the app and be redirected to the dashboard once they log in. Additionally, the user will not access the protected routes until they login.

#### How should this be manually tested?

Pull the changes on a new branch and run `npm install`
Run `npm start` to start the server
Log into the app using a registered email and password
You should be redirected to the dashboard where you can view your profile

To log out, click on the profile icon and select the `Logout` menu.
To test accessing the protected routes, enter `http://localhost:3000/create-article/` to create an article. You should be redirected to the login page to login first.


#### What are the relevant pivotal tracker stories?

- [#162043486](https://www.pivotaltracker.com/story/show/162043486)


## Checklist: I completed these to help reviewers

- [x] My IDE is configured to follow the [**ESlint Conventions**](https://github.com/eslint/eslint)


- [x] I have **added tests** to cover my changes.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the develop branch.

